### PR TITLE
module: fix module name to full gopath

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gohook
+module github.com/brahma-adshonor/gohook
 
 go 1.12
 


### PR DESCRIPTION
Fix module name to full gopath.

When set `GOPROXY`, can't `go get` with the following error:

```sh
> go get -u -v -x github.com/brahma-adshonor/gohook
# get https://proxy.golang.org/github.com/brahma-adshonor/gohook/@v/list
# get https://proxy.golang.org/github.com/brahma-adshonor/gohook/@v/list: 200 OK (0.431s)
go: finding github.com/brahma-adshonor/gohook latest
# get https://proxy.golang.org/github.com/brahma-adshonor/gohook/@latest
# get https://proxy.golang.org/github.com/brahma-adshonor/gohook/@latest: 200 OK (0.047s)
go get: github.com/brahma-adshonor/gohook@v0.0.0-20190725021725-6fff52d522db: parsing go.mod:
        module declares its path as: github.com/brahma-adshonor/gohook
                but was required as: gohook
```