### PR TITLE
fix trampoline function inlined

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -18,6 +18,7 @@ func foo2(v1 int, v2 string) int {
 	return v1 + 4200
 }
 
+//go:noinline
 func foo3(v1 int, v2 string) int {
 	fmt.Printf("foo3:%d(%s)\n", v1, v2)
 	return v1 + 10000
@@ -46,6 +47,7 @@ func myBuffWriteString(b *bytes.Buffer, s string) (int, error) {
 	return 1000 + l, nil
 }
 
+//go:noinline
 func myBuffWriteStringTramp(b *bytes.Buffer, s string) (int, error) {
 	fmt.Printf("fake buffer WriteString tramp, s:%s\n", s)
 	return 0, nil

--- a/example/main.go
+++ b/example/main.go
@@ -19,6 +19,7 @@ func foo2(v1 int, v2 string) int {
 	return v1 + 4200
 }
 
+//go:noinline
 func foo3(v1 int, v2 string) int {
 	fmt.Printf("foo3:%d(%s)\n", v1, v2)
 	return v1 + 10000
@@ -40,6 +41,7 @@ func myBuffLen(b *bytes.Buffer) int {
 	return 233
 }
 
+//go:noinline
 func myBuffLenTramp(b *bytes.Buffer) int {
 	fmt.Printf("start testing...\n")
 	fmt.Printf("start testing...\n")
@@ -118,6 +120,7 @@ func victim(a, b, c int, e, f, g string) int {
 	return 1 + victim(a+1, b-1, c-1, e, f, g)
 }
 
+//go:noinline
 func victimTrampoline(a, b, c int, e, f, g string) int {
 	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
 	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)

--- a/example/unwind.go
+++ b/example/unwind.go
@@ -37,6 +37,7 @@ func main() {
 	foo(-22)
 }
 
+//go:noinline
 func foo_trampoline(k int) int {
 	defer func(k int) { fmt.Printf("k:%d\n", k)}(k)
 


### PR DESCRIPTION
In go1.12.7, the function of example will inline.

The trampoline function must add `//go:noinline`, Prevent future compiler optimizations from inline it.