### PR TITLE
support hook function by indirect jmp using rdx

### DIFF
--- a/arch_util.go
+++ b/arch_util.go
@@ -740,73 +740,101 @@ func fixFuncInstructionInplace(mode int, addr, to uintptr, funcSz int, move_sz i
 	return fix, nil
 }
 
-func genJumpCode(mode int, to, from uintptr) []byte {
+func genJumpCode(mode int, rdxIndirect bool, to, from uintptr) []byte {
 	// 1. use relaive jump if |from-to| < 2G
 	// 2. otherwise, push target, then ret
 
 	var code []byte
 
-	delta := int64(from - to)
-	if unsafe.Sizeof(uintptr(0)) == unsafe.Sizeof(int32(0)) {
-		delta = int64(int32(from - to))
-	}
-
-	relative := (delta <= 0x7fffffff)
-
-	if delta < 0 {
-		delta = -delta
-		relative = (delta <= 0x80000000)
-	}
-
-	// relative = false
-
-	if relative {
-		var dis uint32
-		if to > from {
-			dis = uint32(int32(to-from) - 5)
+	if rdxIndirect {
+		// rdx indirect jump.
+		// by convention, rdx is the context register pointed to funcval
+		if mode == 32 {
+			code = []byte{
+				0xBA,
+				byte(to),
+				byte(to >> 8),
+				byte(to >> 16),
+				byte(to >> 24), // mov edx,to
+				0xFF, 0x22,     // jmp DWORD PTR [edx]
+			}
 		} else {
-			dis = uint32(-int32(from-to) - 5)
-		}
-		code = []byte{
-			0xe9,
-			byte(dis),
-			byte(dis >> 8),
-			byte(dis >> 16),
-			byte(dis >> 24),
-		}
-	} else if mode == 32 {
-		code = []byte{
-			0x68, // push
-			byte(to),
-			byte(to >> 8),
-			byte(to >> 16),
-			byte(to >> 24),
-			0xc3, // retn
-		}
-	} else if mode == 64 {
-		// push does not operate on 64bit imm, workarounds are:
-		// 1. move to register(eg, %rdx), then push %rdx, however, overwriting register may cause problem if not handled carefully.
-		// 2. push twice, preferred.
-		/*
-		   code = []byte{
-		       0x48, // prefix
-		       0xba, // mov to %rdx
-		       byte(to), byte(to >> 8), byte(to >> 16), byte(to >> 24),
-		       byte(to >> 32), byte(to >> 40), byte(to >> 48), byte(to >> 56),
-		       0x52, // push %rdx
-		       0xc3, // retn
-		   }
-		*/
-		code = []byte{
-			0x68, //push
-			byte(to), byte(to >> 8), byte(to >> 16), byte(to >> 24),
-			0xc7, 0x44, 0x24, // mov $value, 4%rsp
-			0x04, // rsp + 4
-			byte(to >> 32), byte(to >> 40), byte(to >> 48), byte(to >> 56),
-			0xc3, // retn
+			code = []byte{
+				0x48, 0xBA,
+				byte(to),
+				byte(to >> 8),
+				byte(to >> 16),
+				byte(to >> 24),
+				byte(to >> 32),
+				byte(to >> 40),
+				byte(to >> 48),
+				byte(to >> 56), // movabs rdx,to
+				0xFF, 0x22,     // jmp QWORD PTR [rdx]
+			}
 		}
 	} else {
-		panic("invalid mode")
+		delta := int64(from - to)
+		if unsafe.Sizeof(uintptr(0)) == unsafe.Sizeof(int32(0)) {
+			delta = int64(int32(from - to))
+		}
+
+		relative := (delta <= 0x7fffffff)
+
+		if delta < 0 {
+			delta = -delta
+			relative = (delta <= 0x80000000)
+		}
+
+		// relative = false
+
+		if relative {
+			var dis uint32
+			if to > from {
+				dis = uint32(int32(to-from) - 5)
+			} else {
+				dis = uint32(-int32(from-to) - 5)
+			}
+			code = []byte{
+				0xe9,
+				byte(dis),
+				byte(dis >> 8),
+				byte(dis >> 16),
+				byte(dis >> 24),
+			}
+		} else if mode == 32 {
+			code = []byte{
+				0x68, // push
+				byte(to),
+				byte(to >> 8),
+				byte(to >> 16),
+				byte(to >> 24),
+				0xc3, // retn
+			}
+		} else if mode == 64 {
+			// push does not operate on 64bit imm, workarounds are:
+			// 1. move to register(eg, %rdx), then push %rdx, however, overwriting register may cause problem if not handled carefully.
+			// 2. push twice, preferred.
+			/*
+			   code = []byte{
+			       0x48, // prefix
+			       0xba, // mov to %rdx
+			       byte(to), byte(to >> 8), byte(to >> 16), byte(to >> 24),
+			       byte(to >> 32), byte(to >> 40), byte(to >> 48), byte(to >> 56),
+			       0x52, // push %rdx
+			       0xc3, // retn
+			   }
+			*/
+			code = []byte{
+				0x68, //push
+				byte(to), byte(to >> 8), byte(to >> 16), byte(to >> 24),
+				0xc7, 0x44, 0x24, // mov $value, 4%rsp
+				0x04, // rsp + 4
+				byte(to >> 32), byte(to >> 40), byte(to >> 48), byte(to >> 56),
+				0xc3, // retn
+			}
+		} else {
+			panic("invalid mode")
+		}
 	}
 
 	sz := len(code)

--- a/hook.go
+++ b/hook.go
@@ -32,6 +32,17 @@ func GetArchMode() int {
 	return archMode
 }
 
+// valueStruct is taken from runtime source code.
+// it may be changed in later release
+type valueStruct struct {
+	typ uintptr
+	ptr uintptr
+}
+
+func getDataPtrFromValue(v reflect.Value) uintptr {
+	return (uintptr)((*valueStruct)(unsafe.Pointer(&v)).ptr)
+}
+
 func ShowDebugInfo() string {
 	buff := bytes.NewBuffer(make([]byte, 0, 256))
 	for k, v := range g_all {
@@ -146,8 +157,8 @@ func doHook(mode int, rdxIndirect bool, target, replacement, trampoline reflect.
 
 	replaceAddr := replacement.Pointer()
 	if rdxIndirect {
-		// FIXME, func value ptr is not accessible.
-		replaceAddr = replacement.UnsafeAddr()
+		// get data ptr out of a reflect value.
+		replaceAddr = getDataPtrFromValue(replacement)
 	}
 
 	info, err := hookFunction(mode, rdxIndirect, target.Pointer(), replaceAddr, tp)

--- a/utility.go
+++ b/utility.go
@@ -96,7 +96,8 @@ func doFixFuncInplace(mode int, addr, to uintptr, funcSz, to_sz int, info *CodeI
 		}
 	}
 
-	jumpcode2 := genJumpCode(mode, addr+uintptr(jumpSize), to+uintptr(size2))
+	//jump from trampoline back to origin func
+	jumpcode2 := genJumpCode(mode, false, addr+uintptr(jumpSize), to+uintptr(size2))
 
 	origin := makeSliceFromPointer(addr, int(total_len))
 	sf := make([]byte, total_len)
@@ -143,9 +144,9 @@ func doCopyFunction(mode int, allowCall bool, from, to uintptr, sz1, sz2 uint32,
 	return sf, nil
 }
 
-func hookFunction(mode int, target, replace, trampoline uintptr) (*CodeInfo, error) {
+func hookFunction(mode int, rdxIndirect bool, target, replace, trampoline uintptr) (*CodeInfo, error) {
 	info := &CodeInfo{}
-	jumpcode := genJumpCode(mode, replace, target)
+	jumpcode := genJumpCode(mode, rdxIndirect, replace, target)
 
 	insLen := len(jumpcode)
 	if trampoline != uintptr(0) {
@@ -203,7 +204,7 @@ func hookFunction(mode int, target, replace, trampoline uintptr) (*CodeInfo, err
 				info.Fix = append(info.Fix, v)
 			}
 
-			jumpcode2 := genJumpCode(mode, target+uintptr(target_body_off), trampoline+uintptr(insLen))
+			jumpcode2 := genJumpCode(mode, false, target+uintptr(target_body_off), trampoline+uintptr(insLen))
 			f2 := makeSliceFromPointer(trampoline, insLen+len(jumpcode2)*2)
 			insLen2 := GetInsLenGreaterThan(mode, f2, insLen+len(jumpcode2))
 			info.TrampolineOrig = make([]byte, insLen2)


### PR DESCRIPTION
this will make it possible to hook function created by reflect.MakeFunc, however, the implementation relys on guessing the memory layout of reflect.Value, which may vary for different version of runtime.