### PR TITLE
Sort mark, add prefix to test code

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -7,27 +7,28 @@ import (
 )
 
 //go:noinline
-func foo1(v1 int, v2 string) int {
-	fmt.Printf("foo1:%d(%s)\n", v1, v2)
+func ex_foo1(v1 int, v2 string) int {
+	fmt.Printf("ex_foo1:%d(%s)\n", v1, v2)
 	return v1 + 42
 }
 
-func foo2(v1 int, v2 string) int {
-	fmt.Printf("foo2:%d(%s)\n", v1, v2)
-	v1 = foo3(100, "not calling foo3")
+//go:noinline
+func ex_foo2(v1 int, v2 string) int {
+	fmt.Printf("ex_foo2:%d(%s)\n", v1, v2)
+	v1 = ex_foo3(100, "not calling foo3")
 	return v1 + 4200
 }
 
 //go:noinline
-func foo3(v1 int, v2 string) int {
-	fmt.Printf("foo3:%d(%s)\n", v1, v2)
+func ex_foo3(v1 int, v2 string) int {
+	fmt.Printf("ex_foo3:%d(%s)\n", v1, v2)
 	return v1 + 10000
 }
 
 func hookFunc() {
-	ret1 := foo1(23, "miliao for foo1 before hook")
+	ret1 := ex_foo1(23, "miliao for foo1 before hook")
 
-	err := gohook.Hook(foo1, foo2, foo3)
+	err := gohook.Hook(ex_foo1, ex_foo2, ex_foo3)
 
 	fmt.Printf("hook done\n")
 	if err != nil {
@@ -35,7 +36,7 @@ func hookFunc() {
 		return
 	}
 
-	ret2 := foo1(23, "miliao for foo1 after hook")
+	ret2 := ex_foo1(23, "miliao for foo1 after hook")
 
 	fmt.Printf("r1:%d, r2:%d\n", ret1, ret2)
 }
@@ -53,13 +54,13 @@ func myBuffWriteStringTramp(b *bytes.Buffer, s string) (int, error) {
 	return 0, nil
 }
 
-func myBuffLen(b *bytes.Buffer) int {
+func ex_myBuffLen(b *bytes.Buffer) int {
 	fmt.Println("calling myBuffLen")
-	return 233 + myBuffLenTramp(b)
+	return 233 + ex_myBuffLenTramp(b)
 }
 
 //go:noinline
-func myBuffLenTramp(b *bytes.Buffer) int {
+func ex_myBuffLenTramp(b *bytes.Buffer) int {
 	fmt.Println("calling myBuffLenTramp1")
 	fmt.Println("calling myBuffLenTramp2")
 	fmt.Println("calling myBuffLenTramp3")
@@ -80,18 +81,18 @@ func hookMethod() {
 	sz1 := buff.Len()
 
 	fmt.Printf("try hook bytes.Buffer.Len()\n")
-	err2 := gohook.HookMethod(buff, "Len", myBuffLen, myBuffLenTramp)
+	err2 := gohook.HookMethod(buff, "Len", ex_myBuffLen, ex_myBuffLenTramp)
 	if err2 != nil {
 		fmt.Printf("hook Len() fail, err:%s\n", err2.Error())
 		return
 	}
 
 	sz2 := buff.Len()
-	sz3 := myBuffLenTramp(buff)
+	sz3 := ex_myBuffLenTramp(buff)
 
 	gohook.UnHookMethod(buff, "Len")
 
-	sz4 := myBuffLen(buff)
+	sz4 := ex_myBuffLen(buff)
 	fmt.Printf("old sz:%d, new sz:%d, copy func:%d, recover:%d\n", sz1, sz2, sz3, sz4)
 }
 

--- a/example/example2.go
+++ b/example/example2.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"github.com/brahma-adshonor/gohook"
+	"os"
 )
 
 func myPrintln(a ...interface{}) (n int, err error) {

--- a/example/main.go
+++ b/example/main.go
@@ -1,173 +1,36 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"golang.org/x/arch/x86/x86asm"
 	"github.com/brahma-adshonor/gohook"
+	"os"
 )
 
-//go:noinline
-func foo1(v1 int, v2 string) int {
-	fmt.Printf("foo1:%d(%s)\n", v1, v2)
-	return v1 + 42
-}
-
-func foo2(v1 int, v2 string) int {
-	fmt.Printf("foo2:%d(%s)\n", v1, v2)
-	v1 = foo3(100, "not calling foo3")
-	return v1 + 4200
+func myPrintln(a ...interface{}) (n int, err error) {
+	fmt.Fprintln(os.Stdout, "before real Printfln")
+	return myPrintlnTramp(a...)
 }
 
 //go:noinline
-func foo3(v1 int, v2 string) int {
-	fmt.Printf("foo3:%d(%s)\n", v1, v2)
-	return v1 + 10000
-}
+func myPrintlnTramp(a ...interface{}) (n int, err error) {
+	// a dummy function to make room for a shadow copy of the original function.
+	// it doesn't matter what we do here, just to create an adequate size function.
+	myPrintlnTramp(a...)
+	myPrintlnTramp(a...)
+	myPrintlnTramp(a...)
 
-func TestAsm() {
-	fmt.Printf("start testing...\n")
+	for {
+		fmt.Printf("hello")
+	}
 
-	ret1 := foo1(23, "sval for foo1")
-
-	gohook.Hook(foo1, foo2, foo3)
-
-	ret2 := foo1(23, "sval for foo1")
-
-	fmt.Printf("r1:%d, r2:%d\n", ret1, ret2)
-}
-
-func myBuffLen(b *bytes.Buffer) int {
-	return 233
-}
-
-//go:noinline
-func myBuffLenTramp(b *bytes.Buffer) int {
-	fmt.Printf("start testing...\n")
-	fmt.Printf("start testing...\n")
-	fmt.Printf("start testing...\n")
-	fmt.Printf("start testing...\n")
-	fmt.Printf("start testing...\n")
-	fmt.Printf("start testing...\n")
-	return 1000
+	return 0, nil
 }
 
 func main() {
-	TestStackGrowth()
-	buff := bytes.NewBufferString("abcd")
-	fmt.Printf("len(buff):%d\n", buff.Len())
+	gohook.Hook(fmt.Println, myPrintln, myPrintlnTramp)
+	fn := fmt.Println
+	fn("hello world!")
+	fmt.Println("hello world!")
 
-	err1 := gohook.HookMethod(buff, "Len", myBuffLen, myBuffLenTramp)
-	if err1 != nil {
-		fmt.Printf("errors:%s\n", err1.Error())
-	}
-
-	info := gohook.ShowDebugInfo()
-	fmt.Printf("show debug info:\n%s\n", info)
-
-	TestAsm()
-
-	//code := []byte {0x64,0x48,0x8b,0x0c,0x25,0xf8,0xff,0xff,0xff,0x48,0x3b,0x61}
-	//code := []byte {0x48,0x3b,0x61,0x10}
-	//code := []byte {0x8d,0x6c,0x24,0x10}
-	//code := []byte{0x64, 0x48, 0x8b, 0xc, 0x25, 0xf8, 0xff, 0xff, 0xff}
-	code := []byte{0xC7, 0x44, 0x24, 0xFC, 0x01, 0x02, 0x03, 0x04}
-	//code := []byte {0x0f,0x86,0xa1,0x00, 0x00,0x00,0x00,0x00}
-	//code := []byte {0xe8,0x8f,0x89,0xe0,0xff}
-	inst, err := x86asm.Decode(code, 64)
-	if err != nil {
-		fmt.Printf("decode failed\n")
-		return
-	}
-
-	fmt.Printf("op:%s,code:%x,len:%d,prefix:", inst.Op.String(), inst.Opcode, inst.Len)
-	for _, v := range inst.Prefix {
-		if v == 0 {
-			break
-		}
-		fmt.Printf(" %s", v.String())
-	}
-	fmt.Printf(",args:")
-	for _, v := range inst.Args {
-		if v == nil {
-			break
-		}
-		fmt.Printf(" %s", v.String())
-	}
-
-	fmt.Printf("\n")
-
-	fullInstLen := gohook.GetInsLenGreaterThan(gohook.GetArchMode(), code, 11)
-	fmt.Printf("full inst len:%d\n", fullInstLen)
-}
-
-func victim(a, b, c int, e, f, g string) int {
-	if a > 100 {
-		return 42
-	}
-
-	var someBigStackArray [4096]byte // to occupy stack, don't let it escape
-	for i := 0; i < len(someBigStackArray); i++ {
-		someBigStackArray[i] = byte((a ^ b) & (i ^ c))
-	}
-
-	if (a % 2) != 0 {
-		someBigStackArray[200] = 0xe9
-	}
-
-	fmt.Printf("calling real victim() (%s,%s,%s,%x):%dth\n", e, f, g, someBigStackArray[200], a)
-
-	return 1 + victim(a+1, b-1, c-1, e, f, g)
-}
-
-//go:noinline
-func victimTrampoline(a, b, c int, e, f, g string) int {
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-	fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", e, f, g, a, 0x23)
-
-	for {
-		if (a % 2) != 0 {
-			fmt.Printf("calling victim()(%s,%s,%s,%x):%dth\n", a, e, f, g, 0x23)
-		} else {
-			a++
-		}
-
-		if a+b > 100 {
-			break
-		}
-
-		buff := bytes.NewBufferString("something weird")
-		fmt.Printf("len:%d\n", buff.Len())
-	}
-
-	return 1
-}
-
-func victimReplace(a, b, c int, e, f, g string) int {
-	fmt.Printf("victimReplace sends its regard\n")
-	ret := 0
-	if a > 100 {
-		ret = 100000
-	}
-
-	return ret + victimTrampoline(a, b, c, e, f, g)
-}
-
-func TestStackGrowth() {
-	gohook.SetMinJmpCodeSize(64)
-	defer gohook.SetMinJmpCodeSize(0)
-
-	gohook.Hook(victim, victimReplace, victimTrampoline)
-
-	victim(0, 1000, 100000, "ab", "miliao", "see")
+	fmt.Printf("debug info:\n%s\n", gohook.ShowDebugInfo())
 }


### PR DESCRIPTION
Recently, this library is used. In the example directory, IDE prompts errors and function conflicts.

Looking at the code, it is found that there are duplicate definitions in the same package, and the IDE also prompts sorting, so the prefix ex is added and the import is sorted

<font color='red'> At present, I can run successfully in local, please verify whether to merge </font>


Thanks！！